### PR TITLE
Feature/replace title with setext for hr tag

### DIFF
--- a/github/create/profile/src/formula/formula.py
+++ b/github/create/profile/src/formula/formula.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 from mdutils.mdutils import MdUtils
 
-title = '<h1><img src="https://emojis.slackmojis.com/emojis/images/1531849430/4246/blob-sunglasses.gif?1531849430" width="30"/> Hello World ! </h1>'
+title = '<h1><img src="https://emojis.slackmojis.com/emojis/images/1531849430/4246/blob-sunglasses.gif?1531849430" width="30"/> Hello World ! </h1> <hr>'
 resume = 'My name is {}. I work as a {} at {}.'
 
 visitors = '![](http://estruyf-github.azurewebsites.net/api/VisitorHit?user={}&repo={}&countColorcountColor)'
@@ -21,7 +21,7 @@ medium = '<a href="{}"><img src="https://img.shields.io/badge/-Medium-%2312100E?
 
 
 def run(username, name, job, company, hardskills, accounts):
-    mdFile = MdUtils(file_name='README', title=title)
+    mdFile = MdUtils(file_name='README')
 
     add_introduction(mdFile, username, name, job, company)
 
@@ -37,6 +37,9 @@ def run(username, name, job, company, hardskills, accounts):
 
     print('\n✅ \033[1mGithub profile README.md file created successfully for {} user!\033[0m'.format(username))
 
+
+def add_title(mdFile, title):
+    mdFile.new_paragraph(resume.format(title))
 
 def add_introduction(mdFile, username, name, job, company):
     mdFile.new_paragraph(resume.format(name, job, company))

--- a/github/create/profile/src/formula/formula.py
+++ b/github/create/profile/src/formula/formula.py
@@ -23,6 +23,8 @@ medium = '<a href="{}"><img src="https://img.shields.io/badge/-Medium-%2312100E?
 def run(username, name, job, company, hardskills, accounts):
     mdFile = MdUtils(file_name='README')
 
+    add_title(mdFile, title)
+
     add_introduction(mdFile, username, name, job, company)
 
     if hardskills is not None:


### PR DESCRIPTION
Hello, I have a simple contribution.

When you create a Title using MdUtils the default text style is Setext (https://en.wikipedia.org/wiki/Setext). So, if your title has X char, you get X * '=' below the title. But isn't responsive. 
Replace the below title ==== for a <hr> we have a responsive separetor between title and content.

First I would like to know if these changes are interesting for the main project.
If your response is yes, I'll need some help to test this feature :D


Before:
![before](https://user-images.githubusercontent.com/84889191/120052276-da4ada80-bffa-11eb-8490-73654b5e9aaf.png)

After:
![after](https://user-images.githubusercontent.com/84889191/120052275-d9b24400-bffa-11eb-8029-ce8ef1703c23.png)
