### PR TITLE
fix add_title

### DIFF
--- a/github/create/profile/src/formula/formula.py
+++ b/github/create/profile/src/formula/formula.py
@@ -41,7 +41,7 @@ def run(username, name, job, company, hardskills, accounts):
 
 
 def add_title(mdFile, title):
-    mdFile.new_paragraph(resume.format(title))
+    mdFile.new_paragraph(title)
 
 def add_introduction(mdFile, username, name, job, company):
     mdFile.new_paragraph(resume.format(name, job, company))


### PR DESCRIPTION
## A small correction

### Error example:
```shell
Traceback (most recent call last):
  File "/Users/jc/.rit/tmp/e60b1548-57be-4e4e-b877-6eb46b3314b8/main.py", line 13, in <module>
    formula.run(username, name, job, company, hardskills, accounts)
  File "/Users/jc/.rit/tmp/e60b1548-57be-4e4e-b877-6eb46b3314b8/formula/formula.py", line 26, in run
    add_title(mdFile, title)
  File "/Users/jc/.rit/tmp/e60b1548-57be-4e4e-b877-6eb46b3314b8/formula/formula.py", line 44, in add_title
    mdFile.new_paragraph(resume.format(title))
IndexError: Replacement index 1 out of range for positional args tuple
Error: exit status 1
```